### PR TITLE
Fix segfault when can't connect

### DIFF
--- a/ios/RNSSH.m
+++ b/ios/RNSSH.m
@@ -18,6 +18,9 @@ RCT_EXPORT_METHOD(execute:(NSDictionary *)config command:(NSString *)command res
     // Authenticate
     if (session.isConnected) {
         [session authenticateByPassword:config[@"password"]];
+    } else {
+      NSError *connectError = [[NSError alloc] initWithDomain:@"RNSSH" code:404 userInfo:@{@"Error reason": @"Can't connect"}];
+      return reject(@"rnssh_could_not_connect", @"RNSSH: could not connect", connectError);
     }
 
     // Execute the command and disconnect

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "author": "",
   "license": "",
   "peerDependencies": {
-    "react-native": "^0.40.0"
+    "react-native": "0.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "author": "",
   "license": "",
   "peerDependencies": {
-    "react-native": "^0.35.0"
+    "react-native": "^0.40.0"
   }
 }


### PR DESCRIPTION
On iOS, if the client can't connect to a server (e.g., server isn't found) the app will crash because we're attempting to operate on a non-existent session, which causes a segfault.

To prevent, I've rejected the promise when we can't connect.

I'm also using the library on RN 0.40.0, and it works great, so I updated the peer dependency to 0.x.x.  Otherwise, I can't use the library because of 0.35.0 restriction.

Thanks!