### PR TITLE
iOS: Reject promise if NMSSH cannot authenticate

### DIFF
--- a/ios/RNSSH.m
+++ b/ios/RNSSH.m
@@ -14,13 +14,16 @@ RCT_EXPORT_METHOD(execute:(NSDictionary *)config command:(NSString *)command res
 {
     // Create the SSH session
     NMSSHSession *session = [NMSSHSession connectToHost:config[@"host"] withUsername:config[@"user"]];
+    if (!session.isConnected) {
+        NSError *connectError = [[NSError alloc] initWithDomain:@"RNSSH" code:404 userInfo:@{@"Error reason": @"Can't connect"}];
+        return reject(@"rnssh_could_not_connect", @"RNSSH: could not connect", connectError);
+    }
 
     // Authenticate
-    if (session.isConnected) {
-        [session authenticateByPassword:config[@"password"]];
-    } else {
-      NSError *connectError = [[NSError alloc] initWithDomain:@"RNSSH" code:404 userInfo:@{@"Error reason": @"Can't connect"}];
-      return reject(@"rnssh_could_not_connect", @"RNSSH: could not connect", connectError);
+    BOOL authenticated = [session authenticateByPassword:config[@"password"]];
+    if (!authenticated) {
+        NSError *authError = [[NSError alloc] initWithDomain:@"RNSSH" code:401 userInfo:@{@"Error reason": @"Can't authenticate"}];
+        return reject(@"rnssh_could_not_authenticate", @"RNSSH: could not authenticate", authError);
     }
 
     // Execute the command and disconnect


### PR DESCRIPTION
Currently, the `execute` promise neither resolves nor rejects if the credentials provided are wrong. This PR adds an authenticated check and a promise rejection if the credentials are wrong.